### PR TITLE
chore(build): update release github-action script to generate amd64 and arm64 fro Linux and Darwin system 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,10 +19,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Run go mod tidy
         run: go mod tidy
-      - name: build binaries
-        run: make build-arm build-linux
-      - name: archive binaries
-        run: make archive-bin-arm archive-bin-linux
+      - name: build & archive binaries
+        run: make archive-release
       - name: upload artifacts
         uses: actions/upload-artifact@master
         with:

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,14 @@ vet:
 build:
 	$(GO) build -o bin/yomo -ldflags "-s -w ${GO_LDFLAGS}" ./yomo/main.go
 
-build-arm:
-	GOARCH=arm64 GOOS=linux $(GO) build -o bin/yomo-${VER}-aarch64-linux -ldflags "-s -w ${GO_LDFLAGS}" ./yomo/main.go
+build-release:
+	GOARCH=arm64 GOOS=darwin $(GO) build -o bin/yomo-${VER}-arm64-Darwin -ldflags "-s -w ${GO_LDFLAGS}" ./yomo/main.go
+	GOARCH=amd64 GOOS=darwin $(GO) build -o bin/yomo-${VER}-x86_64-Darwin -ldflags "-s -w ${GO_LDFLAGS}" ./yomo/main.go
+	GOARCH=arm64 GOOS=linux $(GO) build -o bin/yomo-${VER}-arm64-Linux -ldflags "-s -w ${GO_LDFLAGS}" ./yomo/main.go
+	GOARCH=amd64 GOOS=linux $(GO) build -o bin/yomo-${VER}-x86_64-Linux -ldflags "-s -w ${GO_LDFLAGS}" ./yomo/main.go
 
-build-linux:
-	GOOS=linux $(GO) build -o bin/yomo-${VER}-x86_64-linux -ldflags "-s -w ${GO_LDFLAGS}" ./yomo/main.go
-
-archive-bin-arm:
-	tar -czf bin/yomo-${VER}-aarch64-linux.tar.gz bin/yomo-${VER}-aarch64-linux
-
-archive-bin-linux:
-	tar -czf bin/yomo-${VER}-x86_64-linux.tar.gz bin/yomo-${VER}-x86_64-linux
+archive-release: build-release
+	tar -czf bin/yomo-${VER}-arm64-Darwin.tar.gz bin/yomo-${VER}-arm64-Darwin
+	tar -czf bin/yomo-${VER}-x86_64-Darwin.tar.gz bin/yomo-${VER}-x86_64-Darwin
+	tar -czf bin/yomo-${VER}-arm64-Linux.tar.gz bin/yomo-${VER}-arm64-Linux
+	tar -czf bin/yomo-${VER}-x86_64-Linux.tar.gz bin/yomo-${VER}-x86_64-Linux

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # YoMo CLI
+
 Command-line tools for YoMo
 
-## Prerequisites
+## Binary
+
+`curl -sL https://github.com/yomorun/cli/releases/download/v0.1.3/yomo-v0.1.3-`uname -m`-`uname -s`.tar.gz | tar xvfz -`
+
+## Build from source
 
 [Installing Go](https://golang.org/doc/install)
 
-## Installing
 You can easily install the latest release globally by running:
 
 ```sh
 go install github.com/yomorun/cli/yomo@latest
 ```
+
 Or you can install into another directory:
 
 ```sh

--- a/bina.json
+++ b/bina.json
@@ -1,0 +1,20 @@
+{
+    "platforms": {
+      "darwin-arm64": {
+        "asset": "yomo-v0.1.3-arm64-Darin.tar.gz",
+        "file": "bin/yomo"
+      },
+      "darwin-amd64": {
+        "asset": "yomo-v0.1.3-x86_64-Darin.tar.gz",
+        "file": "bin/yomo"
+      },
+      "linux-arm64": {
+        "asset": "yomo-v0.1.3-arm64-Linux.tar.gz",
+        "file": "bin/yomo"
+      },
+      "linux-amd64": {
+        "asset": "yomo-v0.1.3-x86_64-Linux.tar.gz",
+        "file": "bin/yomo"
+      }
+    }
+  }


### PR DESCRIPTION
Developers can get `yomo` binary by: 

```bash
$ curl -sL https://github.com/yomorun/cli/releases/download/v0.1.3/yomo-v0.1.3-`uname -m`-`uname -s`.tar.gz | tar xvfz -
```