### PR TITLE
fix: keep the dependency the same version of yomo

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -131,6 +131,8 @@ tasks:
     cmds:
       - "{{.ExeDir}}/{{.ExeName}} run -n Noise -m example/go.mod example/js/stream-fn/app.js"
     silent: false
+    env:
+      YOMO_CREDENTIAL: token:1234
 
   example-js-stream-fn-db:
     desc: run output stream-fn-db
@@ -138,6 +140,8 @@ tasks:
     cmds:
       - "{{.ExeDir}}/{{.ExeName}} run -n MockDB -m example/go.mod example/js/stream-fn-db/app.js"
     silent: false
+    env:
+      YOMO_CREDENTIAL: token:1234
 
   version:
     desc: "print version"

--- a/serverless/golang/serverless.go
+++ b/serverless/golang/serverless.go
@@ -157,7 +157,7 @@ func (s *GolangServerless) Build(clean bool) error {
 		}
 	} else {
 		// Upgrade modules that provide packages imported by packages in the main module
-		cmd := exec.Command("go", "get", "-d", "-u", "./...")
+		cmd := exec.Command("go", "get", "-d", "./...")
 		cmd.Dir = s.tempDir
 		cmd.Env = env
 		out, err := cmd.CombinedOutput()

--- a/serverless/js/serverless.go
+++ b/serverless/js/serverless.go
@@ -47,9 +47,9 @@ func (s *JsServerless) Init(opts *serverless.Options) error {
 	// append main function
 	credential := viper.GetString("credential")
 	ctx := Context{
-		Name: s.opts.Name,
-		Host: s.opts.Host,
-		Port: s.opts.Port,
+		Name:       s.opts.Name,
+		Host:       s.opts.Host,
+		Port:       s.opts.Port,
 		Credential: credential,
 	}
 
@@ -145,7 +145,7 @@ func (s *JsServerless) Build(clean bool) error {
 		}
 	} else {
 		// Upgrade modules that provide packages imported by packages in the main module
-		cmd := exec.Command("go", "get", "-d", "-u", "./...")
+		cmd := exec.Command("go", "get", "-d", "./...")
 		cmd.Dir = s.tempDir
 		cmd.Env = env
 		out, err := cmd.CombinedOutput()


### PR DESCRIPTION
Do not use `go get -u` to download latest dependencies and keep the same version of yomo to avoid dependency conflicts.