### PR TITLE
fix(wasm): reset output when the handler function is called

### DIFF
--- a/serverless/wasm/wasmedge.go
+++ b/serverless/wasm/wasmedge.go
@@ -97,6 +97,9 @@ func (r *wasmEdgeRuntime) GetObserveDataTags() []byte {
 // RunHandler runs the wasm application (request -> response mode)
 func (r *wasmEdgeRuntime) RunHandler(data []byte) (byte, []byte, error) {
 	r.input = data
+	// reset output
+	r.outputTag = 0
+	r.output = nil
 
 	// Run the handler function. Given the pointer to the input data.
 	if _, err := r.vm.Execute(WasmFuncHandler, int32(len(data))); err != nil {

--- a/serverless/wasm/wasmtime.go
+++ b/serverless/wasm/wasmtime.go
@@ -89,7 +89,11 @@ func (r *wasmtimeRuntime) GetObserveDataTags() []byte {
 // RunHandler runs the wasm application (request -> response mode)
 func (r *wasmtimeRuntime) RunHandler(data []byte) (byte, []byte, error) {
 	r.input = data
+	// reset output
+	r.outputTag = 0
+	r.output = nil
 
+	// run handler
 	if _, err := r.handler.Call(r.store, len(data)); err != nil {
 		return 0, nil, fmt.Errorf("handler.Call: %v", err)
 	}


### PR DESCRIPTION
The output was cached and sent to zipper every time when the handler was called, but I expected the handler should only return the output when `counter % 3 == 0`.

<img width="495" alt="image" src="https://user-images.githubusercontent.com/48110142/190336471-c9418b22-13be-4cbc-97a4-9b656c3dbce1.png">
